### PR TITLE
Fix/browser runtime test reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
       - name: Run checks
         run: ./scripts/check.sh

--- a/assets/ts/custom-cursor.ts
+++ b/assets/ts/custom-cursor.ts
@@ -87,8 +87,8 @@ function setState(state: string) {
   }
 }
 
-function updateStateFromTarget(target: HTMLElement | null) {
-  if (!target) {
+function updateStateFromTarget(target: EventTarget | null) {
+  if (!(target instanceof Element)) {
     setState("default");
     return;
   }
@@ -115,7 +115,7 @@ function updateStateFromTarget(target: HTMLElement | null) {
 }
 
 function handleMouseOver(e: MouseEvent) {
-  updateStateFromTarget(e.target as HTMLElement);
+  updateStateFromTarget(e.target);
 }
 
 function handleMouseDown() {
@@ -133,7 +133,7 @@ function handleMouseLeave(e: MouseEvent) {
 }
 
 function handleMouseEnter(e: MouseEvent) {
-  updateStateFromTarget(e.target as HTMLElement);
+  updateStateFromTarget(e.target);
 }
 
 function handleClick(e: MouseEvent) {

--- a/internal/embedded/static/js/custom-cursor.js
+++ b/internal/embedded/static/js/custom-cursor.js
@@ -346,7 +346,7 @@
     }
   }
   function updateStateFromTarget(target) {
-    if (!target) {
+    if (!(target instanceof Element)) {
       setState("default");
       return;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@fontsource/allura": "^5.3.0",
         "@fontsource/cormorant-garamond": "^5.3.0",
         "@fontsource/fraunces": "^5.3.0",
-        "@playwright/test": "^1.62.1",
         "@waline/client": "^3.15.2",
         "esbuild": "^0.28.2",
         "katex": "^0.18.4",
@@ -570,22 +569,6 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
-      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.62.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=20"
-      }
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@fontsource/allura": "^5.3.0",
     "@fontsource/cormorant-garamond": "^5.3.0",
     "@fontsource/fraunces": "^5.3.0",
-    "@playwright/test": "^1.62.1",
     "@waline/client": "^3.15.2",
     "esbuild": "^0.28.2",
     "katex": "^0.18.4",

--- a/scripts/browser-test.mjs
+++ b/scripts/browser-test.mjs
@@ -1,12 +1,4 @@
-import { test, expect, chromium } from '@playwright/test';
-import { spawn } from 'child_process';
-import path from 'path';
-import fs from 'fs';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const root = path.resolve(__dirname, '..');
+import { chromium } from 'playwright';
 
 const serverPort = 1313;
 const serverUrl = `http://localhost:${serverPort}`;
@@ -22,8 +14,6 @@ async function run() {
   const errors = [];
   
   page.on('pageerror', err => {
-    // Ignore unrelated pre-existing bugs 
-    if (err.message.includes('target.closest is not a function')) return;
     errors.push(`PageError: ${err.message}`);
   });
   
@@ -82,6 +72,17 @@ async function run() {
     if (initialPath === scrolledPath) {
       throw new Error('TOC SVG path did not animate after scrolling (spring physics inactive).');
     }
+    
+    console.log('Testing custom cursor regression...');
+    await page.evaluate(() => {
+      const enterEvent = new MouseEvent('mouseenter', { bubbles: true });
+      document.dispatchEvent(enterEvent);
+      
+      const leaveEvent = new MouseEvent('mouseleave', { bubbles: true });
+      document.dispatchEvent(leaveEvent);
+    });
+    
+    if (errors.length > 0) throw new Error(errors.join('\n'));
     
     console.log('Testing browser back...');
     await page.goBack();

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 echo "==> Phase A: Dependency and Frontend Validation"
-npm ci
+if [ -z "${CI:-}" ]; then npm ci; fi
 npm run typecheck
 npm run test:reading-rail
 npm run build:js
@@ -12,7 +12,15 @@ echo "==> Phase B: Go Validation"
 go test ./...
 
 TEMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TEMP_DIR"; kill $(jobs -p) 2>/dev/null || true' EXIT
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "${TEMP_DIR:-}"
+}
+trap cleanup EXIT INT TERM
 
 DAYBOOK_BIN="$TEMP_DIR/daybook-bin"
 echo "==> Building Daybook binary to $DAYBOOK_BIN"
@@ -97,12 +105,38 @@ fi
 echo "==> Starting Daybook dev server"
 "$DAYBOOK_BIN" serve &
 SERVER_PID=$!
-sleep 2
+
+max_attempts=20
+attempt=1
+ready=0
+while [ $attempt -le $max_attempts ]; do
+  sleep 0.2
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "ERROR: Daybook test server failed to start on port 1313."
+    echo "Make sure port 1313 is available before running ./scripts/check.sh."
+    exit 1
+  fi
+  
+  if curl -s -f http://localhost:1313/ > /dev/null; then
+    ready=1
+    break
+  fi
+  attempt=$((attempt + 1))
+done
+
+sleep 0.2
+if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+  echo "ERROR: Daybook test server exited unexpectedly."
+  exit 1
+fi
+
+if [ $ready -eq 0 ]; then
+  echo "ERROR: Daybook test server did not become ready in time."
+  exit 1
+fi
 
 echo "==> Phase D: Browser Runtime Regression Test"
 cd - > /dev/null
 node scripts/browser-test.mjs
-
-kill $SERVER_PID || true
 
 echo "==> All checks passed successfully!"


### PR DESCRIPTION
# PR Report: Harden Browser Runtime Checks

**Branch**: `fix/browser-runtime-test-reliability`
**Status**: Pushed (Do not auto-merge)

## 1. Custom Cursor EventTarget Bug Fix
The `TypeError: target.closest is not a function` error has been fixed.
- **Root Cause**: The custom cursor code registered `mouseenter`/`mouseover` listeners on the `document` itself. When the event fired on the document, `e.target` was the `Document` node, which is a valid `EventTarget` but not an `Element`, meaning it lacks the `.closest()` method. The unsafe `as HTMLElement` cast in TypeScript merely masked this mismatch, allowing it to compile but throwing at runtime.
- **Fix**: The `updateStateFromTarget` signature was changed to safely accept `EventTarget | null`. Inside the function, we explicitly verify `if (!(target instanceof Element)) { ... }` before ever attempting to call `.closest()`.
- **Testing**: The whitelist ignoring this specific error in `browser-test.mjs` was deleted. We added a focused regression test that explicitly dispatches `mouseenter` and `mouseleave` events directly to the `document` via Playwright. Uncaught PageErrors are now unconditionally treated as fatal test failures.

## 2. Test Server Fail-Fast & Readiness
The `check.sh` script now reliably fails if `localhost:1313` is already occupied, instead of connecting Playwright to a foreign server.
- **Fail-Fast**: A retry loop runs for up to 20 attempts (max ~4 seconds). Inside the loop, it checks `kill -0 "$SERVER_PID"` to verify if the server crashed (e.g. from `bind: address already in use`). If the process exited, `check.sh` aborts with a clear error: `ERROR: Daybook test server failed to start on port 1313`.
- **Readiness**: If the process is alive, it queries `http://localhost:1313/` using `curl`. Only if `curl` succeeds and the process is still alive does it proceed to Phase D.
- **Port Handling**: We deliberately maintained the fixed port `1313` architecture, avoiding port-scanner bloat or dynamic port allocation. Developers are simply required to keep 1313 open before running the full check script.
- **Process Cleanup**: Replaced inline traps with a dedicated `cleanup()` bash function that gracefully handles SIGTERM and standard exits, ensuring `SERVER_PID` is always cleanly terminated and waited upon.

## 3. Playwright CI Installation & Dependency Cleanup
- **GitHub Actions**: Added the explicit step `npx playwright install --with-deps chromium` to `.github/workflows/ci.yml`. This ensures that the GitHub CI runner downloads the necessary headless Chromium binaries required for Phase D without bloating the test suite with Firefox or WebKit.
- **Dependency Audit**: The redundant `@playwright/test` framework was removed from `package.json` (`playwright` standalone browser automation API is sufficient).
- **Import Cleanup**: Dead imports (`fs`, `path`, `spawn`, `test`, `expect`) were purged from `browser-test.mjs`.

## 4. Full Regression Pass
Both local and CI environments successfully executed the full regression matrix:
- ✅ View Transition SPA invocation
- ✅ KaTeX `.katex` DOM presence
- ✅ TOC Rail SVG path mutation (spring physics simulation)
- ✅ Custom Cursor mouseenter regression
- ✅ Browser back navigation
- ✅ Absolute Zero PageErrors

## Scope Affirmation
- No modifications were made to the PR #9 IIFE/ESM architecture.
- No dynamic port features were added.
- No curl installer was developed.

**PR URL**: https://github.com/StatIndet/daybook/pull/new/fix/browser-runtime-test-reliability
<!-- GOAL_COMPLETE -->
