### PR TITLE
fix: 阅读页目录位置、移动端交互和主题切换优化

### DIFF
--- a/assets/ts/custom-cursor.ts
+++ b/assets/ts/custom-cursor.ts
@@ -133,10 +133,17 @@ function handleMouseLeave(e: MouseEvent) {
 }
 
 function handleMouseEnter(e: MouseEvent) {
+  // document 级 mouseenter 的 target 是 document（非 Element），
+  // 不能在窗口进入时把 mouseover 已算好的状态重置为 default
+  if (!(e.target instanceof Element)) return;
   updateStateFromTarget(e.target);
 }
 
-function handleClick(e: MouseEvent) {
+function isArticleDetailPage() {
+  return document.body?.dataset.pageKind === "note";
+}
+
+function toggleClockEffect() {
   if (document.documentElement.getAttribute('data-clock-cursor') !== 'true') {
     return;
   }
@@ -148,6 +155,16 @@ function handleClick(e: MouseEvent) {
       clockController.start(cursorX, cursorY);
     }
   }
+}
+
+function handleClick() {
+  if (isArticleDetailPage()) return;
+  toggleClockEffect();
+}
+
+function handleDoubleClick() {
+  if (!isArticleDetailPage()) return;
+  toggleClockEffect();
 }
 
 function handleVisibilityChange() {
@@ -216,6 +233,7 @@ function setupCustomCursor() {
   document.addEventListener("mouseleave", handleMouseLeave);
   document.addEventListener("mouseenter", handleMouseEnter);
   document.addEventListener("click", handleClick, { passive: true });
+  document.addEventListener("dblclick", handleDoubleClick, { passive: true });
   document.addEventListener("visibilitychange", handleVisibilityChange);
   document.addEventListener("daybook:page-load", handlePageLoad);
 
@@ -232,6 +250,7 @@ function teardownCustomCursor() {
   document.removeEventListener("mouseleave", handleMouseLeave);
   document.removeEventListener("mouseenter", handleMouseEnter);
   document.removeEventListener("click", handleClick);
+  document.removeEventListener("dblclick", handleDoubleClick);
   document.removeEventListener("visibilitychange", handleVisibilityChange);
   document.removeEventListener("daybook:page-load", handlePageLoad);
 

--- a/assets/ts/embeds.ts
+++ b/assets/ts/embeds.ts
@@ -2,7 +2,7 @@ import { createFallbackElement, setupIframeEmbeds } from "./embed-loading.js";
 import { setupImages } from "./image-loader.js";
 
 (function () {
-  var compactNumberFormat = new Intl.NumberFormat("en_US", {
+  var compactNumberFormat = new Intl.NumberFormat("en-US", {
     notation: "compact",
     maximumFractionDigits: 1,
   });

--- a/assets/ts/mobile-toc.ts
+++ b/assets/ts/mobile-toc.ts
@@ -2,6 +2,16 @@
  * Mobile TOC Controller
  * Manages the floating action button (FAB) and the bottom sheet for the Table of Contents on small screens.
  */
+function headingIdFromLink(link: HTMLAnchorElement): string {
+  const rawId = link.getAttribute("href")?.substring(1) || "";
+
+  try {
+    return decodeURIComponent(rawId);
+  } catch {
+    return rawId;
+  }
+}
+
 class MobileTocController {
   private readonly fab: HTMLElement;
   private readonly sheet: HTMLElement;
@@ -54,7 +64,7 @@ class MobileTocController {
     this.listItems.forEach(item => {
       const link = item.querySelector("a");
       if (link) {
-        const id = link.getAttribute("href")?.substring(1);
+        const id = headingIdFromLink(link);
         if (id) {
           const element = document.getElementById(id);
           if (element) {
@@ -73,7 +83,7 @@ class MobileTocController {
       const link = item.querySelector("a");
       link?.addEventListener("click", (e) => {
         e.preventDefault();
-        const id = link.getAttribute("href")?.substring(1);
+        const id = headingIdFromLink(link);
         const target = document.getElementById(id || "");
         if (target) {
           target.scrollIntoView({ behavior: "smooth" });

--- a/assets/ts/theme.ts
+++ b/assets/ts/theme.ts
@@ -270,6 +270,33 @@
 
   let isTransitioning = false;
 
+  // 兜底：后台标签页中 View Transition 的 finished 可能永不 resolve，
+  // 导致 isTransitioning 锁死、后续点击被静默丢弃
+  function releaseTransitionLock(attributeName: string) {
+    clearThemeTransition(attributeName);
+    isTransitioning = false;
+  }
+
+  function guardedTransition(attributeName: string, updateCallback: () => void) {
+    isTransitioning = true;
+    try {
+      const transition = document.startViewTransition!(updateCallback);
+      transition.finished.then(function() {
+        releaseTransitionLock(attributeName);
+      }, function() {
+        releaseTransitionLock(attributeName);
+      });
+      // 2 秒超时兜底
+      setTimeout(function() {
+        releaseTransitionLock(attributeName);
+      }, 2000);
+    } catch (e) {
+      // startViewTransition 同步抛错时也要释放锁
+      updateCallback();
+      releaseTransitionLock(attributeName);
+    }
+  }
+
   document.addEventListener("click", function (event: MouseEvent) {
     if (isTransitioning) return;
 
@@ -299,18 +326,11 @@
         setTimeout(function() {
           root.style.setProperty("view-transition-name", "theme-toggle-transition");
           root.dataset['themeChanging'] = "true";
-          const transition = document.startViewTransition!(function() {
+          guardedTransition("themeChanging", function() {
             root.dataset['theme'] = nextResolved;
             syncThemeButtons();
           });
-          transition.finished.then(function() {
-            clearThemeTransition("themeChanging");
-            isTransitioning = false;
-          }, function() {
-            clearThemeTransition("themeChanging");
-            isTransitioning = false;
-          });
-        }, 350); 
+        }, 350);
       }
       return;
     }
@@ -324,26 +344,21 @@
       const nextResolved = nextMode === "system" ? getSystemPreferredTheme() : nextMode;
       const currentResolved = root.dataset['theme'];
 
+      // 立即更新按钮状态和模式，不等待 View Transition 捕获帧
+      // 用户点击后立刻看到图标变化，背景色通过过渡动画渐变
+      root.dataset['themeMode'] = nextMode;
+      storeThemeMode(nextMode);
+      syncThemeButtons();
+
       if (nextResolved === currentResolved || !shouldAnimateTheme()) {
-        applyThemeMode(nextMode, true);
+        root.dataset['theme'] = nextResolved;
         return;
       }
 
-      isTransitioning = true;
-      // Start view transition immediately for desktop, active state gives physical feedback
       root.style.setProperty("view-transition-name", "theme-toggle-transition");
       root.dataset['themeChanging'] = "true";
-
-      const themeTransition = document.startViewTransition!(function () {
-        applyThemeMode(nextMode, true);
-      });
-
-      themeTransition.finished.then(function () {
-        clearThemeTransition("themeChanging");
-        isTransitioning = false;
-      }, function () {
-        clearThemeTransition("themeChanging");
-        isTransitioning = false;
+      guardedTransition("themeChanging", function () {
+        root.dataset['theme'] = nextResolved;
       });
 
       return;
@@ -367,17 +382,8 @@
       setTimeout(function () {
         root.style.setProperty("view-transition-name", "palette-toggle-transition");
         root.dataset['paletteChanging'] = nextPalette === "warm" ? "to-warm" : "from-warm";
-
-        const paletteTransition = document.startViewTransition!(function () {
+        guardedTransition("paletteChanging", function () {
           applyPalette(nextPalette, true);
-        });
-
-        paletteTransition.finished.then(function () {
-          clearThemeTransition("paletteChanging");
-          isTransitioning = false;
-        }, function () {
-          clearThemeTransition("paletteChanging");
-          isTransitioning = false;
         });
       }, 350);
     }

--- a/assets/ts/toc.ts
+++ b/assets/ts/toc.ts
@@ -376,6 +376,15 @@ class NoteTocController {
     if (currentLink) {
       event.preventDefault();
       this.jumpToHeading(this.activeIndex);
+      return;
+    }
+
+    const tocLink = target.closest<HTMLAnchorElement>(".note-toc-panel a[href^=\"#\"]");
+    if (tocLink) {
+      event.preventDefault();
+      const id = headingIdFromLink(tocLink);
+      const headingIndex = this.headings.findIndex((heading) => heading.id === id);
+      this.jumpToHeading(headingIndex);
     }
   };
 
@@ -391,7 +400,8 @@ class NoteTocController {
     });
 
     const url = new URL(window.location.href);
-    url.hash = heading.id;
+    const rawHash = heading.link.getAttribute("href");
+    url.hash = rawHash?.startsWith("#") ? rawHash.slice(1) : heading.id;
     const state = history.state;
     const nextState = state && typeof state === "object"
       ? { ...state, url: url.href }

--- a/internal/embedded/static/css/pages/note.css
+++ b/internal/embedded/static/css/pages/note.css
@@ -125,7 +125,10 @@
 .article-meta-rows {
   margin: 1.2rem 0 0;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 0.6rem;
   color: var(--color-muted);
   font-family: var(--font-meta);
@@ -186,6 +189,90 @@
   line-height: 0.92;
   margin-top: 4px;
   padding: 4px 10px 0 0;
+}
+
+/* Article pages use the existing site-info column as the desktop reading rail. */
+@media (min-width: 1281px) {
+  /* 整栏上移，让作者块与左侧常驻 logo（--persistent-logo-top）同高；
+     min-height 同步补偿，保持底部链接区相对视口底的位置不变 */
+  .notes-aside.note-page-aside {
+    --note-aside-lift: calc(clamp(56px, 7vw, 88px) - var(--persistent-logo-top));
+
+    margin-top: calc(-1 * var(--note-aside-lift));
+    min-height: calc(100vh - 176px + var(--note-aside-lift));
+    top: var(--persistent-logo-top);
+  }
+
+  .note-page-aside .notes-aside-identity {
+    align-self: flex-end;
+    max-width: 100%;
+    text-align: right;
+  }
+
+  .note-page-aside .notes-brand-name {
+    justify-content: flex-end;
+  }
+
+  .note-page-aside .notes-brand-cn {
+    font-size: clamp(1.05rem, 1.4vw, 1.35rem);
+  }
+
+  .note-page-aside .notes-brand-en {
+    font-size: clamp(0.95rem, 1.2vw, 1.15rem);
+  }
+
+  .note-page-aside .notes-brand-slogan {
+    font-size: 0.72rem;
+    margin-top: 0.45rem;
+    text-wrap: balance;
+  }
+
+  .note-page-aside .note-aside-toc {
+    margin-top: clamp(2.5rem, 7vh, 4rem);
+    min-width: 0;
+  }
+
+  .note-page-aside .note-toc {
+    font-size: 0.86rem;
+  }
+
+  .note-page-aside .note-toc-wrapper {
+    bottom: auto;
+    pointer-events: auto;
+    position: static;
+    right: auto;
+    top: auto;
+    width: 100%;
+  }
+
+  .note-page-aside .note-sticky-column,
+  .note-page-aside .note-toc-stage,
+  .note-page-aside .note-toc {
+    width: 100%;
+  }
+
+  .note-page-aside .note-sticky-column {
+    position: static;
+  }
+
+  .note-page-aside .note-toc {
+    margin-bottom: 0;
+    max-width: none;
+  }
+
+  .note-page-aside .note-toc-panel {
+    max-height: min(calc(100vh - 260px), 32rem);
+  }
+
+  /* 阅读控件沉到右栏底部、贴着工具行上方；auto 外边距吸收中部留白，
+     控件存在时工具行改用固定间距（不存在时保持原有 margin-top:auto 沉底） */
+  .note-page-aside .note-aside-reading-controls {
+    margin-top: auto;
+  }
+
+  .note-page-aside .note-aside-reading-controls ~ .notes-aside-controls {
+    margin-top: clamp(1.5rem, 3vh, 2.25rem);
+  }
 }
 
 @media (min-width: 116rem) {
@@ -354,13 +441,7 @@ html[data-reduced-motion="true"] .note-toc-stage .note-toc {
 }
 
 .note-tags {
-  margin-top: clamp(3rem, 5vw, 4.5rem);
-}
-
-.note-tags-divider {
-  border: 0;
-  border-top: 1px dashed var(--color-line);
-  margin: 0 0 1.5rem;
+  margin-top: clamp(0.75rem, 1.5vw, 1.25rem);
 }
 
 .note-tags-list {

--- a/internal/embedded/static/js/custom-cursor.js
+++ b/internal/embedded/static/js/custom-cursor.js
@@ -386,9 +386,13 @@
     }
   }
   function handleMouseEnter(e) {
+    if (!(e.target instanceof Element)) return;
     updateStateFromTarget(e.target);
   }
-  function handleClick(e) {
+  function isArticleDetailPage() {
+    return document.body?.dataset.pageKind === "note";
+  }
+  function toggleClockEffect() {
     if (document.documentElement.getAttribute("data-clock-cursor") !== "true") {
       return;
     }
@@ -400,6 +404,14 @@
         clockController.start(cursorX, cursorY);
       }
     }
+  }
+  function handleClick() {
+    if (isArticleDetailPage()) return;
+    toggleClockEffect();
+  }
+  function handleDoubleClick() {
+    if (!isArticleDetailPage()) return;
+    toggleClockEffect();
   }
   function handleVisibilityChange() {
     if (document.hidden) breakIdleClock(false);
@@ -456,6 +468,7 @@
     document.addEventListener("mouseleave", handleMouseLeave);
     document.addEventListener("mouseenter", handleMouseEnter);
     document.addEventListener("click", handleClick, { passive: true });
+    document.addEventListener("dblclick", handleDoubleClick, { passive: true });
     document.addEventListener("visibilitychange", handleVisibilityChange);
     document.addEventListener("daybook:page-load", handlePageLoad);
     isInitialized = true;
@@ -469,6 +482,7 @@
     document.removeEventListener("mouseleave", handleMouseLeave);
     document.removeEventListener("mouseenter", handleMouseEnter);
     document.removeEventListener("click", handleClick);
+    document.removeEventListener("dblclick", handleDoubleClick);
     document.removeEventListener("visibilitychange", handleVisibilityChange);
     document.removeEventListener("daybook:page-load", handlePageLoad);
     if (rafId !== null) {

--- a/internal/embedded/static/js/embeds.js
+++ b/internal/embedded/static/js/embeds.js
@@ -102,7 +102,7 @@
 
   // assets/ts/embeds.ts
   (function() {
-    var compactNumberFormat = new Intl.NumberFormat("en_US", {
+    var compactNumberFormat = new Intl.NumberFormat("en-US", {
       notation: "compact",
       maximumFractionDigits: 1
     });

--- a/internal/embedded/static/js/mobile-toc.js
+++ b/internal/embedded/static/js/mobile-toc.js
@@ -1,6 +1,14 @@
 "use strict";
 (() => {
   // assets/ts/mobile-toc.ts
+  function headingIdFromLink(link) {
+    const rawId = link.getAttribute("href")?.substring(1) || "";
+    try {
+      return decodeURIComponent(rawId);
+    } catch {
+      return rawId;
+    }
+  }
   var MobileTocController = class {
     constructor(fab, sheet, backdrop, panel, dragHandle, tocNav, indicator, listItems, postContent) {
       this.headings = [];
@@ -59,7 +67,7 @@
       this.listItems.forEach((item) => {
         const link = item.querySelector("a");
         if (link) {
-          const id = link.getAttribute("href")?.substring(1);
+          const id = headingIdFromLink(link);
           if (id) {
             const element = document.getElementById(id);
             if (element) {
@@ -74,7 +82,7 @@
         const link = item.querySelector("a");
         link?.addEventListener("click", (e) => {
           e.preventDefault();
-          const id = link.getAttribute("href")?.substring(1);
+          const id = headingIdFromLink(link);
           const target = document.getElementById(id || "");
           if (target) {
             target.scrollIntoView({ behavior: "smooth" });

--- a/internal/embedded/static/js/theme.js
+++ b/internal/embedded/static/js/theme.js
@@ -233,6 +233,27 @@
     document.addEventListener("pointerup", removePressedState);
     document.addEventListener("pointercancel", removePressedState);
     let isTransitioning = false;
+    function releaseTransitionLock(attributeName) {
+      clearThemeTransition(attributeName);
+      isTransitioning = false;
+    }
+    function guardedTransition(attributeName, updateCallback) {
+      isTransitioning = true;
+      try {
+        const transition = document.startViewTransition(updateCallback);
+        transition.finished.then(function() {
+          releaseTransitionLock(attributeName);
+        }, function() {
+          releaseTransitionLock(attributeName);
+        });
+        setTimeout(function() {
+          releaseTransitionLock(attributeName);
+        }, 2e3);
+      } catch (e) {
+        updateCallback();
+        releaseTransitionLock(attributeName);
+      }
+    }
     document.addEventListener("click", function(event) {
       if (isTransitioning) return;
       const target = event.target;
@@ -254,16 +275,9 @@
           setTimeout(function() {
             root.style.setProperty("view-transition-name", "theme-toggle-transition");
             root.dataset["themeChanging"] = "true";
-            const transition = document.startViewTransition(function() {
+            guardedTransition("themeChanging", function() {
               root.dataset["theme"] = nextResolved;
               syncThemeButtons();
-            });
-            transition.finished.then(function() {
-              clearThemeTransition("themeChanging");
-              isTransitioning = false;
-            }, function() {
-              clearThemeTransition("themeChanging");
-              isTransitioning = false;
             });
           }, 350);
         }
@@ -275,22 +289,17 @@
         const nextMode = currentMode === "system" ? "light" : currentMode === "light" ? "dark" : "system";
         const nextResolved = nextMode === "system" ? getSystemPreferredTheme() : nextMode;
         const currentResolved = root.dataset["theme"];
+        root.dataset["themeMode"] = nextMode;
+        storeThemeMode(nextMode);
+        syncThemeButtons();
         if (nextResolved === currentResolved || !shouldAnimateTheme()) {
-          applyThemeMode(nextMode, true);
+          root.dataset["theme"] = nextResolved;
           return;
         }
-        isTransitioning = true;
         root.style.setProperty("view-transition-name", "theme-toggle-transition");
         root.dataset["themeChanging"] = "true";
-        const themeTransition = document.startViewTransition(function() {
-          applyThemeMode(nextMode, true);
-        });
-        themeTransition.finished.then(function() {
-          clearThemeTransition("themeChanging");
-          isTransitioning = false;
-        }, function() {
-          clearThemeTransition("themeChanging");
-          isTransitioning = false;
+        guardedTransition("themeChanging", function() {
+          root.dataset["theme"] = nextResolved;
         });
         return;
       }
@@ -309,15 +318,8 @@
         setTimeout(function() {
           root.style.setProperty("view-transition-name", "palette-toggle-transition");
           root.dataset["paletteChanging"] = nextPalette === "warm" ? "to-warm" : "from-warm";
-          const paletteTransition = document.startViewTransition(function() {
+          guardedTransition("paletteChanging", function() {
             applyPalette(nextPalette, true);
-          });
-          paletteTransition.finished.then(function() {
-            clearThemeTransition("paletteChanging");
-            isTransitioning = false;
-          }, function() {
-            clearThemeTransition("paletteChanging");
-            isTransitioning = false;
           });
         }, 350);
       }

--- a/internal/embedded/static/js/toc.js
+++ b/internal/embedded/static/js/toc.js
@@ -768,6 +768,14 @@
         if (currentLink) {
           event.preventDefault();
           this.jumpToHeading(this.activeIndex);
+          return;
+        }
+        const tocLink = target.closest('.note-toc-panel a[href^="#"]');
+        if (tocLink) {
+          event.preventDefault();
+          const id = headingIdFromLink(tocLink);
+          const headingIndex = this.headings.findIndex((heading) => heading.id === id);
+          this.jumpToHeading(headingIndex);
         }
       };
       this.runFrame = (timestamp) => {
@@ -932,7 +940,8 @@
         behavior: this.reducedMotion ? "instant" : "smooth"
       });
       const url = new URL(window.location.href);
-      url.hash = heading.id;
+      const rawHash = heading.link.getAttribute("href");
+      url.hash = rawHash?.startsWith("#") ? rawHash.slice(1) : heading.id;
       const state = history.state;
       const nextState = state && typeof state === "object" ? { ...state, url: url.href } : state;
       history.replaceState(nextState, "", `${url.pathname}${url.search}${url.hash}`);

--- a/internal/embedded/templates/pages/note.html
+++ b/internal/embedded/templates/pages/note.html
@@ -85,16 +85,19 @@
             {{end}}
           </div>
         </div>
+
+        {{if .Note.Tags}}
+        <section class="note-tags" aria-label="{{T .Lang "action.tags"}}">
+          <div class="note-tags-list">
+            {{range .Note.Tags}}
+            <a href="{{tagURL $.Lang .}}" class="note-tag-capsule">#{{.}}</a>
+            {{end}}
+          </div>
+        </section>
+        {{end}}
+
         {{with .Note.Summary}}<p class="note-summary">{{.}}</p>{{end}}
       </header>
-
-      {{if .Note.TocEnabled}}
-      <div class="note-toc-wrapper">
-        <div class="note-sticky-column">
-          {{template "toc" .}}
-        </div>
-      </div>
-      {{end}}
 
       {{if .Note.TocEnabled}}
       {{template "mobile-toc" .}}
@@ -103,17 +106,6 @@
       <div class="markdown post-content">
         {{.Note.HTML}}
       </div>
-
-      {{if .Note.Tags}}
-      <section class="note-tags" aria-label="{{T .Lang "action.tags"}}">
-        <hr class="note-tags-divider">
-        <div class="note-tags-list">
-          {{range .Note.Tags}}
-          <a href="{{tagURL $.Lang .}}" class="note-tag-capsule">#{{.}}</a>
-          {{end}}
-        </div>
-      </section>
-      {{end}}
 
       {{if .Note.CommentEnabled}}
       <section class="post-comments">
@@ -132,6 +124,6 @@
     </article>
   </section>
 
-  {{template "notes_aside" .}}
+  {{template "note_aside" .}}
 </div>
 {{end}}

--- a/internal/embedded/templates/partials/footer.html
+++ b/internal/embedded/templates/partials/footer.html
@@ -11,8 +11,7 @@
 </footer>
 {{end}}
 
-{{define "notes_aside"}}
-<aside class="notes-aside" aria-label="站点信息" data-transition-region="notes-aside">
+{{define "notes_aside_identity"}}
   <div class="notes-brand notes-aside-identity">
     <h1 class="notes-brand-name">
       <span class="notes-brand-cn{{if .Config.Profile.HasSignatureFont}} use-signature-font{{end}}">{{.Config.Profile.Author.Name}}</span>
@@ -20,7 +19,9 @@
     </h1>
     <p class="notes-brand-slogan">{{morphableText (.Config.Profile.GetSlogan .Lang) "site-slogan" "slogan"}}</p>
   </div>
+{{end}}
 
+{{define "notes_aside_controls"}}
   <div class="notes-aside-controls">
     <div class="notes-tools" data-notes-tools>
       <div class="notes-tool-panel notes-search-panel" id="notes-search-panel" data-notes-panel="search" aria-hidden="true">
@@ -51,6 +52,33 @@
       {{template "copyright" dict "Config" .Config "Class" ""}}
     </div>
   </div>
+{{end}}
+
+{{define "notes_aside"}}
+<aside class="notes-aside" aria-label="站点信息" data-transition-region="notes-aside">
+  {{template "notes_aside_identity" .}}
+  {{template "notes_aside_controls" .}}
+</aside>
+{{end}}
+
+{{define "note_aside"}}
+<aside class="notes-aside note-page-aside" aria-label="文章辅助信息" data-transition-region="notes-aside">
+  {{template "notes_aside_identity" .}}
+  {{if .Note.TocEnabled}}
+  <div class="note-aside-toc">
+    <div class="note-toc-wrapper">
+      <div class="note-sticky-column">
+        {{template "toc" .}}
+      </div>
+    </div>
+  </div>
+  {{if .Note.Headings}}
+  <div class="note-aside-reading-controls">
+    {{template "reading_controls" .}}
+  </div>
+  {{end}}
+  {{end}}
+  {{template "notes_aside_controls" .}}
 </aside>
 {{end}}
 

--- a/internal/embedded/templates/partials/toc.html
+++ b/internal/embedded/templates/partials/toc.html
@@ -19,9 +19,6 @@
       </ol>
     </nav>
     <div class="note-toc-divider" aria-hidden="true" style="--toc-index: {{len .Note.Headings}}"></div>
-    <div class="note-toc-reading-controls" style="--toc-index: {{len .Note.Headings}}">
-      {{template "reading_controls" .}}
-    </div>
   </aside>
 
   <nav class="reading-toc-rail" data-reading-toc-rail aria-label="{{if eq .Lang "en_US"}}Reading progress{{else}}阅读进度{{end}}" aria-hidden="true" inert>

--- a/internal/media/remote.go
+++ b/internal/media/remote.go
@@ -1,7 +1,7 @@
 package media
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -61,7 +61,7 @@ func FetchMusicMetadata(urlStr string, publicDir string) (MusicMetadata, error) 
 	meta.Artist = flacMeta.Artist
 
 	if len(flacMeta.CoverData) > 0 {
-		hash := md5.Sum([]byte(urlStr))
+		hash := sha256.Sum256([]byte(urlStr))
 		hashStr := hex.EncodeToString(hash[:])[:12]
 		
 		ext := ".jpg"

--- a/scripts/browser-test.mjs
+++ b/scripts/browser-test.mjs
@@ -38,6 +38,19 @@ async function run() {
   });
 
   try {
+    const clockIsVisible = () => page.evaluate(() =>
+      document.querySelector('.daybook-cursor-clock')?.classList.contains('is-visible') ?? false
+    );
+
+    console.log('Testing homepage single-click clock effect...');
+    await page.goto(`${serverUrl}/`, { waitUntil: 'networkidle' });
+    await page.mouse.move(2400, 1200);
+    await page.mouse.click(2400, 1200);
+    await page.waitForTimeout(100);
+    if (!(await clockIsVisible())) {
+      throw new Error('Homepage single click did not activate the clock cursor effect.');
+    }
+
     console.log('Visiting /notes...');
     await page.goto(`${serverUrl}/notes/`, { waitUntil: 'networkidle' });
     
@@ -48,10 +61,27 @@ async function run() {
     await articleLink.click();
     
     await page.waitForSelector('div.post-content', { state: 'attached', timeout: 5000 });
-    
+
+    if (await clockIsVisible()) {
+      throw new Error('Clock effect was activated by the notes-list link click and carried into the article page.');
+    }
+
     const vtCount = await page.evaluate(() => window.__daybookViewTransitionCount);
     if (vtCount === 0) {
       throw new Error('View Transition API was not called during SPA navigation.');
+    }
+
+    console.log('Testing article double-click clock effect...');
+    await page.mouse.move(2400, 1200);
+    await page.mouse.click(2400, 1200);
+    await page.waitForTimeout(100);
+    if (await clockIsVisible()) {
+      throw new Error('Article single click activated the clock cursor effect.');
+    }
+    await page.mouse.dblclick(2400, 1200);
+    await page.waitForTimeout(100);
+    if (!(await clockIsVisible())) {
+      throw new Error('Article double click did not activate the clock cursor effect.');
     }
     
     console.log('Checking KaTeX render...');
@@ -61,16 +91,38 @@ async function run() {
       throw new Error('KaTeX DOM (.katex) was not generated.');
     }
     
-    console.log('Checking TOC Rail...');
-    await page.waitForSelector('[data-reading-toc-rail-base]', { state: 'attached', timeout: 5000 });
-    
-    const initialPath = await page.getAttribute('[data-reading-toc-rail-base]', 'd');
+    console.log('Checking TOC right rail...');
+    // 目录已移入右侧 sticky 阅读栏（note-page-aside），旧的超宽屏 SVG 弹簧轨道不再启用；
+    // 这里断言新契约：右栏目录可见、滚动后保持 sticky、阅读进度随滚动更新。
+    await page.waitForSelector('.note-page-aside [data-note-toc]', { state: 'visible', timeout: 5000 });
+
+    const railProbe = () => page.evaluate(() => {
+      const wrapper = document.querySelector('.note-page-aside .note-toc-wrapper');
+      const rect = wrapper?.getBoundingClientRect();
+      return {
+        top: rect?.top ?? null,
+        visible: !!rect && rect.bottom > 0 && rect.top < window.innerHeight,
+        progress: document.querySelector('[data-desktop-progress-text]')?.textContent ?? null,
+      };
+    });
+
     await page.evaluate(() => window.scrollBy(0, 500));
-    await page.waitForTimeout(500); 
-    
-    const scrolledPath = await page.getAttribute('[data-reading-toc-rail-base]', 'd');
-    if (initialPath === scrolledPath) {
-      throw new Error('TOC SVG path did not animate after scrolling (spring physics inactive).');
+    await page.waitForTimeout(300);
+    const firstScroll = await railProbe();
+    await page.evaluate(() => window.scrollBy(0, 500));
+    await page.waitForTimeout(300);
+    const secondScroll = await railProbe();
+
+    if (!secondScroll.visible) {
+      throw new Error('TOC right rail is not visible after scrolling.');
+    }
+    if (firstScroll.top === null || secondScroll.top === null
+        || Math.abs(secondScroll.top - firstScroll.top) > 2) {
+      throw new Error('TOC right rail did not stay sticky between scrolled positions.');
+    }
+    if (!secondScroll.progress || secondScroll.progress === '0%'
+        || secondScroll.progress === firstScroll.progress) {
+      throw new Error('Reading progress did not update while scrolling the article.');
     }
     
     console.log('Testing custom cursor regression...');


### PR DESCRIPTION
对应 #15 里提的几个阅读体验问题，都在这个分支上改了。

主要做了这些：

- 目录从正文顶上挪到了右边，做成 sticky，翻页时一直能看到；阅读进度和回顶/到底的按钮放在右栏靠下的位置
- 标签从文章末尾挪到标题下面
- 手机上点目录没反应的问题修了（标题 id 的编码没处理导致的）
- 电脑上目录点第二下卡死的问题也修了
- 文章页的时钟特效改成双击才触发，主页还是单击
- 深色/浅色切换点了马上有反应，之前偶尔点了完全没反应的问题也一起修了

顺手修了两个小东西：封面图缓存文件名从 md5 换成 sha256；同步最新 main 的时候发现 embeds 里有个 locale 写法会让页面打开直接报错，也一起修了。

有一点要说明：目录位置、标签位置、文章页时钟改双击，这些属于默认行为变了；原来超宽屏下的动画阅读轨道在新布局里就没有了。如果想保留旧行为，可以商量做成开关。然后 check.sh 本地全跑过，桌面和手机宽度都看过一遍。
